### PR TITLE
Prevent exception

### DIFF
--- a/classes/event/ModelHandler.php
+++ b/classes/event/ModelHandler.php
@@ -116,6 +116,10 @@ abstract class ModelHandler
     protected function clearItemCache()
     {
         $sItemClass = $this->getItemClass();
+        if (empty($sItemClass)) {
+            return;
+        }
+        
         $sField = $this->sIdentifierField;
 
         $sItemClass::clearCache($this->obElement->$sField);


### PR DESCRIPTION
In some cases `$this->getItemClass();` returns null, giving exception
`Class name must be a valid object or a string
 ../plugins/lovata/toolbox/classes/event/ModelHandler.php#121`