### PR TITLE
Manipulate the $arImportData before initializing preview_image

### DIFF
--- a/classes/helper/AbstractImportModel.php
+++ b/classes/helper/AbstractImportModel.php
@@ -94,8 +94,8 @@ abstract class AbstractImportModel
      */
     protected function run()
     {
-        $this->prepareImportData();
         $this->fireBeforeImportEvent();
+        $this->prepareImportData();
         $this->prepareImportDataBeforeSave();
 
         $this->findByExternalID();


### PR DESCRIPTION
The `$arImportData` that is being returned by the event `EVENT_BEFORE_IMPORT` can now be used by the `prepareImportData` function