### PR TITLE
Allow to create Items from extended models

### DIFF
--- a/classes/item/ElementItem.php
+++ b/classes/item/ElementItem.php
@@ -294,7 +294,7 @@ abstract class ElementItem extends MainItem
      */
     protected function setCachedFieldList()
     {
-        if (!method_exists($this->obElement, 'getCachedField')) {
+        if (!$this->obElement->methodExists('getCachedField')) {
             return;
         }
 


### PR DESCRIPTION
Use `ExtendableTrait::methodExists` instead of `method_exists` in `setCachedFieldList` method