### PR TITLE
Update SendMailHelper.php

### DIFF
--- a/classes/helper/SendMailHelper.php
+++ b/classes/helper/SendMailHelper.php
@@ -31,15 +31,15 @@ class SendMailHelper
 
     /**
      * Send email
-     * @param string $sMailTemplate
-     * @param string $sEmailList
-     * @param array  $arDefaultEmailData
-     * @param string $sEmailDataEventName
-     * @param bool   $bCheckActiveLang
+     * @param string       $sMailTemplate
+     * @param string|array $mEmailList
+     * @param array        $arDefaultEmailData
+     * @param string       $sEmailDataEventName
+     * @param bool         $bCheckActiveLang
      */
-    public function send($sMailTemplate, $sEmailList, $arDefaultEmailData = [], $sEmailDataEventName = null, $bCheckActiveLang = false)
+    public function send($sMailTemplate, $mEmailList, $arDefaultEmailData = [], $sEmailDataEventName = null, $bCheckActiveLang = false)
     {
-        if (empty($sEmailList) || (!is_string($sEmailList) && !is_array($sEmailList))) {
+        if (empty($mEmailList) || (!is_string($mEmailList) && !is_array($mEmailList))) {
             return;
         }
 
@@ -53,10 +53,10 @@ class SendMailHelper
         $this->arMailData = $this->getMailData($sEmailDataEventName, $arDefaultEmailData);
 
         //Process email list
-        if (is_string($sEmailList)) {
-            $arEmailList = explode(',', $sEmailList);
+        if (is_string($mEmailList)) {
+            $arEmailList = explode(',', $mEmailList);
         } else {
-            $arEmailList = $sEmailList;
+            $arEmailList = $mEmailList;
         }
 
         foreach ($arEmailList as $sEmail) {


### PR DESCRIPTION
It might be worth pointing out in the DocBlock that the EmailList variable can be a string or an array. When I pass the email list as an array to the send method, the IDE shows a warning that there must be a string. Although this method, judging by the code, can also accept an array.