### PR TITLE
Update AbstractModelRelationHandler.php

### DIFF
--- a/classes/event/AbstractModelRelationHandler.php
+++ b/classes/event/AbstractModelRelationHandler.php
@@ -21,7 +21,7 @@ abstract class AbstractModelRelationHandler
 
         $sModelClass::extend(function ($obModel) {
             /** @var \Model $obModel */
-            $obModel->bindEvent('model.relation.afterAttach', function ($sRelationName, $arAttachedIDList, $arInsertData) use ($obModel) {
+            $obModel->bindEvent('model.relation.attach', function ($sRelationName, $arAttachedIDList, $arInsertData) use ($obModel) {
                 if (!$this->checkRelationName($sRelationName)) {
                     return;
                 }
@@ -30,7 +30,7 @@ abstract class AbstractModelRelationHandler
                 $this->afterAttach($obModel, $arAttachedIDList, $arInsertData);
             }, $this->iPriority);
 
-            $obModel->bindEvent('model.relation.afterDetach', function ($sRelationName, $arAttachedIDList) use ($obModel) {
+            $obModel->bindEvent('model.relation.detach', function ($sRelationName, $arAttachedIDList) use ($obModel) {
                 if (!$this->checkRelationName($sRelationName)) {
                     return;
                 }

--- a/classes/event/AbstractModelRelationHandler.php
+++ b/classes/event/AbstractModelRelationHandler.php
@@ -20,8 +20,16 @@ abstract class AbstractModelRelationHandler
         $sModelClass = $this->getModelClass();
 
         $sModelClass::extend(function ($obModel) {
+            if (class_exists('System')) {
+                $sAfterAttach = 'model.relation.attach';
+                $sAfterDetach = 'model.relation.detach';
+            }else {
+                $sAfterAttach = 'model.relation.afterAttach';
+                $sAfterDetach = 'model.relation.afterDetach';
+            }
+            
             /** @var \Model $obModel */
-            $obModel->bindEvent('model.relation.attach', function ($sRelationName, $arAttachedIDList, $arInsertData) use ($obModel) {
+            $obModel->bindEvent($sAfterAttach, function ($sRelationName, $arAttachedIDList, $arInsertData) use ($obModel, $sAfterAttach) {
                 if (!$this->checkRelationName($sRelationName)) {
                     return;
                 }
@@ -30,7 +38,7 @@ abstract class AbstractModelRelationHandler
                 $this->afterAttach($obModel, $arAttachedIDList, $arInsertData);
             }, $this->iPriority);
 
-            $obModel->bindEvent('model.relation.detach', function ($sRelationName, $arAttachedIDList) use ($obModel) {
+            $obModel->bindEvent($sAfterDetach, function ($sRelationName, $arAttachedIDList) use ($obModel, $sAfterDetach) {
                 if (!$this->checkRelationName($sRelationName)) {
                     return;
                 }


### PR DESCRIPTION
changed event names for relations in version 2+
It was:
https://github.com/octobercms/library/blob/1.0/src/Database/Relations/BelongsToMany.php#L153
https://github.com/octobercms/library/blob/1.0/src/Database/Relations/BelongsToMany.php#L204

became:
https://github.com/octobercms/library/blob/develop/src/Database/Relations/BelongsToMany.php#L158
https://github.com/octobercms/library/blob/develop/src/Database/Relations/BelongsToMany.php#L211