### PR TITLE
Update AbstractModelRelationHandler.php

### DIFF
--- a/classes/event/AbstractModelRelationHandler.php
+++ b/classes/event/AbstractModelRelationHandler.php
@@ -27,7 +27,7 @@ abstract class AbstractModelRelationHandler
                 $sAfterAttach = 'model.relation.afterAttach';
                 $sAfterDetach = 'model.relation.afterDetach';
             }
-            
+
             /** @var \Model $obModel */
             $obModel->bindEvent($sAfterAttach, function ($sRelationName, $arAttachedIDList, $arInsertData) use ($obModel, $sAfterAttach) {
                 if (!$this->checkRelationName($sRelationName)) {
@@ -41,6 +41,9 @@ abstract class AbstractModelRelationHandler
             $obModel->bindEvent($sAfterDetach, function ($sRelationName, $arAttachedIDList) use ($obModel, $sAfterDetach) {
                 if (!$this->checkRelationName($sRelationName)) {
                     return;
+                }
+                if (is_null($arAttachedIDList)) {
+                    $arAttachedIDList = $obModel->$sRelationName()->newPivotQuery()->lists($obModel->$sRelationName()->getRelatedPivotKeyName());
                 }
 
                 $this->sRelationName = $sRelationName;


### PR DESCRIPTION
Some belongsToMany relationship widgets always submit their content when the form is saved. In cases where such a widget is empty, this can be interpreted as either a complete detach relationship or an empty sheet. In earlier versions, the pivot check was carried out in the detach method, but now there is no such check, and for example, when an empty list of additional categories is saved, an error occurs, or the cache flush does not work because there is no list of detached entities. These changes solve this problem by checking whether bound entities have been deleted or were initially empty.

https://github.com/octobercms/library/blob/1.0/src/Database/Relations/BelongsToMany.php#L166-L168