### PR TITLE
Fix page codes to get correct URLs

### DIFF
--- a/classes/helper/PageHelper.php
+++ b/classes/helper/PageHelper.php
@@ -107,7 +107,7 @@ class PageHelper
 
         //Process page list
         foreach ($obPageList as $obPage) {
-            $arResult[$obPage->id] = $obPage->title;
+            $arResult[$obPage->baseFileName] = $obPage->title;
         }
 
         $this->arPageNameList = $arResult;


### PR DESCRIPTION
If the CMS page is located in a subdirectory (eg pages/catalog/catalog.htm), its id will be catalog-catalog. This id is not suitable for getting a valid URL (CmsPage::url('catalog-catalog') will look for page pages/catalog-catalog.htm).