### PR TITLE
Add CachedModel bahavior

### DIFF
--- a/behaviors/CachedModel.php
+++ b/behaviors/CachedModel.php
@@ -1,0 +1,14 @@
+<?php namespace Lovata\Toolbox\Classes\Behavior;
+
+use October\Rain\Extension\ExtensionBase;
+use Lovata\Toolbox\Traits\Helpers\TraitCached;
+
+/**
+ * Class CachedModel
+ * @package Lovata\Toolbox\Classes\Behavior
+ * @author  Igor Tverdokhleb, i.tverdokhleb@lovata.com, LOVATA Group
+ */
+class CachedModel extends ExtensionBase
+{
+    use TraitCached;
+}

--- a/classes/helper/PageHelper.php
+++ b/classes/helper/PageHelper.php
@@ -107,7 +107,7 @@ class PageHelper
 
         //Process page list
         foreach ($obPageList as $obPage) {
-            $arResult[$obPage->id] = $obPage->title;
+            $arResult[$obPage->baseFileName] = $obPage->title;
         }
 
         $this->arPageNameList = $arResult;


### PR DESCRIPTION
This will allow you to add CachedTrait to a third party model. 

Usage example:

```
ThirdPartyModel::extend(function ($obElement) {
    $obElement->implementClassWith(\Lovata\Toolbox\Classes\Behavior\CachedModel::class);

    $obElement->bindEvent('model.beforeFetch', function() use ($obElement) {
        $obElement->addCachedField([
            'id',
            'field_1',
            'field_2',
            // ...
        ]);
    });
});
```