### PR TITLE
Fixed looping of requests to settings

### DIFF
--- a/models/CommonSettings.php
+++ b/models/CommonSettings.php
@@ -37,29 +37,6 @@ class CommonSettings extends SettingModel
      */
     public static function getValue($sCode, $sDefaultValue = null)
     {
-        if (empty($sCode)) {
-            return $sDefaultValue;
-        }
-
-        if (isset(static::$arCacheValue[$sCode])) {
-            return static::$arCacheValue[$sCode];
-        }
-
-        //Get settings object
-        $obSettings = static::where('item', static::SETTINGS_CODE)->first();
-        if (empty($obSettings)) {
-            static::$arCacheValue[$sCode] = static::get($sCode, $sDefaultValue);
-
-            return static::$arCacheValue[$sCode];
-        }
-
-        $sValue = $obSettings->$sCode;
-        if ($sValue === null) {
-            return $sDefaultValue;
-        }
-
-        static::$arCacheValue[$sCode] = $sValue;
-
-        return $sValue;
+        return static::instance()->$sCode ?? $sDefaultValue;
     }
 }

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -126,3 +126,5 @@
     - 'Fixed PageHelper class.'
 2.1.3:
     - 'Revert fix of PageHelper class.'
+2.1.4:
+    - 'Fixed looping of requests to settings. Thanks to dblackCat and Nikita Khaetsky.'


### PR DESCRIPTION
Previously, I applied this fix manually. Thanks Nikita Khaetsky for the hint.

Nikita wanted to add this pull request himself, but has not done so yet.

I recently updated my build and the site took a very long time to load.

The problem is that requests start to be duplicated, which significantly reduces performance.

This solves the problem.